### PR TITLE
Fix Modal deployment image build argument

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -160,6 +160,30 @@ This will start the frontend development server on [http://localhost:7262](http:
   docker compose down
   ```
 
+## Deploying the Demo on Modal
+
+The repository includes a [`modal_app.py`](../modal_app.py) entrypoint that packages the
+backend and the static frontend into a single GPU-enabled Modal deployment. To publish a
+public URL:
+
+1. [Install the Modal CLI](https://modal.com/docs/guide/setup) and authenticate with
+   `modal token new` if you have not done so already.
+2. From the repository root, run the local entrypoint that performs the deployment and
+   prints the resulting endpoint:
+
+   ```bash
+   modal run modal_app.py::deploy
+   ```
+
+   The command builds the Docker image defined in [`backend.Dockerfile`](../backend.Dockerfile),
+   which now also bundles the production React build. Modal will provision an A10G GPU for the
+   inference service.
+3. Share the printed URL with your users. The same endpoint serves the React frontend and the
+   GraphQL/REST APIs, so no additional proxying is required.
+
+If you need to redeploy after making changes, rerun the `modal run` command above. Modal will
+reuse cached image layers when possible.
+
 ## Contributing
 
 Contributions are welcome! Please read our contributing guidelines to get started.

--- a/demo/backend/server/data/data_types.py
+++ b/demo/backend/server/data/data_types.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass
 from typing import Iterable, List, Optional
 
 import strawberry
-from app_conf import API_URL
 from data.resolver import resolve_videos
 from dataclasses_json import dataclass_json
 from strawberry import relay
@@ -25,11 +24,11 @@ class Video(relay.Node):
 
     @strawberry.field
     def url(self) -> str:
-        return f"{API_URL}/{self.path}"
+        return f"/{self.path}"
 
     @strawberry.field
     def poster_url(self) -> str:
-        return f"{API_URL}/{self.poster_path}"
+        return f"/{self.poster_path}" if self.poster_path else ""
 
     @classmethod
     def resolve_nodes(

--- a/demo/frontend/src/demo/DemoConfig.tsx
+++ b/demo/frontend/src/demo/DemoConfig.tsx
@@ -31,8 +31,21 @@ export const ABOUT_URL = 'https://ai.meta.com/sam2';
 export const EMAIL_ADDRESS = 'segment-anything@meta.com';
 export const BLOG_URL = 'http://ai.meta.com/blog/sam2';
 
-export const VIDEO_API_ENDPOINT = 'http://localhost:7263';
-export const INFERENCE_API_ENDPOINT = 'http://localhost:7263';
+const getDefaultEndpoint = () => {
+  if (typeof window !== 'undefined' && window.location.origin) {
+    return window.location.origin;
+  }
+
+  const {VITE_INFERENCE_API_ENDPOINT} = import.meta.env;
+  if (VITE_INFERENCE_API_ENDPOINT != null) {
+    return VITE_INFERENCE_API_ENDPOINT;
+  }
+
+  return 'http://localhost:7263';
+};
+
+export const VIDEO_API_ENDPOINT = getDefaultEndpoint();
+export const INFERENCE_API_ENDPOINT = getDefaultEndpoint();
 
 export const demoObjectLimit = 3;
 

--- a/modal_app.py
+++ b/modal_app.py
@@ -1,0 +1,63 @@
+"""Modal deployment entrypoint for the SAM 2 demo."""
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+
+import modal
+
+APP_NAME = "sam2-demo"
+
+app = modal.App(APP_NAME)
+
+backend_image = modal.Image.from_dockerfile(
+    path=".",
+    dockerfile="backend.Dockerfile",
+)
+
+
+@app.function(
+    image=backend_image,
+    gpu=modal.gpu.A10G(),
+    timeout=60 * 60,
+    container_idle_timeout=60 * 15,
+    allow_concurrent_inputs=8,
+    env={
+        "SERVER_ENVIRONMENT": "MODAL",
+        "DATA_PATH": "/data",
+        "DEFAULT_VIDEO_PATH": "gallery/05_default_juggle.mp4",
+        "FRONTEND_DIST_PATH": "/opt/sam2/server/frontend_dist",
+    },
+)
+@modal.wsgi_app()
+def sam2_demo():
+    """Expose the Flask app and ensure demo assets are writable."""
+    data_path = Path(os.environ["DATA_PATH"])
+    data_path.mkdir(parents=True, exist_ok=True)
+
+    seed_path = Path("/opt/sam2/server/data")
+    for child in seed_path.iterdir():
+        destination = data_path / child.name
+        if destination.exists():
+            continue
+        if child.is_dir():
+            shutil.copytree(child, destination)
+        else:
+            shutil.copy2(child, destination)
+
+    from app import app as flask_app
+
+    return flask_app
+
+
+@app.local_entrypoint()
+def deploy():
+    """Deploy the Modal app and print the public URL."""
+    deployment = app.deploy()
+    print("SAM 2 demo backend deployed.")
+    for function in deployment.web_endpoints:
+        if function.function_name == "sam2_demo":
+            print(f"Public URL: {function.url}")
+            break
+


### PR DESCRIPTION
## Summary
- build the React frontend inside the backend Docker image so the Flask app can serve it directly
- expose the bundled assets through new Flask routes and make frontend endpoints resolve from the request origin
- add a Modal deployment entrypoint and document the deployment workflow
- fix the Modal image build call to use the supported `path` argument instead of the deprecated `context`

## Testing
- python -m compileall modal_app.py

------
https://chatgpt.com/codex/tasks/task_e_68d3297412108327bf26c54f0a403f6f